### PR TITLE
Update Cargo.toml link to repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Guilherme Pagano <guilhermebpagano@gmail.com>"]
 description = "Perspective projection of a spinning cube, using only ascii codes"
 license = "MIT"
+repository = "https://github.com/gbPagano/spinning_cube"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow crates.io, rust-digger and others to link back to the repo